### PR TITLE
Improve context isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 main.js
 preload.js
 after-pack.js
+dicts.js
 
 .DS_store
 

--- a/dicts.ts
+++ b/dicts.ts
@@ -1,0 +1,20 @@
+import * as fs from 'fs';
+import * as path from 'path';
+/** @type {import('./types/typo-js')} */
+import Typo from 'typo-js';
+
+export async function getDicts(){
+    const dictAU = new Typo('en_AU', await readFile(path.join(__dirname, 'node_modules/dictionary-en-au/index.aff')), await readFile(path.join(__dirname, '/node_modules/dictionary-en-au/index.dic')));
+    const dictUS = new Typo('en_US', await readFile(path.join(__dirname, 'node_modules/dictionary-en/index.aff')), await readFile(path.join(__dirname, '/node_modules/dictionary-en/index.dic')));
+    return {AU: dictAU, US: dictUS}
+}
+
+
+function readFile(path: string): Promise<string> {
+	return new Promise<string>(resolve => {
+		fs.readFile(path, (err, data) => {
+			if (!!err) resolve('');
+			resolve(data.toString());
+		});
+	});
+}

--- a/package.json
+++ b/package.json
@@ -29,16 +29,11 @@
 		"typescript": "~4.5.4"
 	},
 	"dependencies": {
-		"@electron/remote": "^2.0.1",
 		"dictionary-en": "^3.0.0",
 		"dictionary-en-au": "^2.1.1",
-		"electron-context-menu": "git+https://github.com/NickGeek/electron-context-menu.git#97ee9ecd43b9fd2186b085d4a5b8732ff99fcee6",
-		"electron-is-dev": "git+https://github.com/NickGeek/electron-is-dev.git#a5350fb9f004106a2f0d8bd7eb27d4fcd179dada",
+		"electron-context-menu": "^3.1.2",
 		"localforage": "^1.10.0",
 		"typo-js": "^1.2.1"
-	},
-	"resolutions": {
-		"electron-is-dev": "git+https://github.com/NickGeek/electron-is-dev.git#a5350fb9f004106a2f0d8bd7eb27d4fcd179dada"
 	},
 	"build": {
 		"appId": "com.getmicropad.micropad",

--- a/preload.ts
+++ b/preload.ts
@@ -1,140 +1,51 @@
-import { webFrame } from 'electron';
-/** @type {import('./types/typo-js')} */
-import Typo from 'typo-js';
+import { ipcRenderer, webFrame } from 'electron';
 import * as fs from 'fs';
-import ContextMenu from 'electron-context-menu';
-import * as path from 'path';
-import { dialog, Menu, MenuItem } from '@electron/remote';
 import localforage from 'localforage';
-
-interface IWindow {
-	isElectron: boolean;
-}
+import { getDicts } from './dicts';
+const { contextBridge } = require('electron')
 
 let userDict: Set<string> = new Set();
-let shouldSpellCheck = true;
 
 function init() {
-	getWindow().isElectron = true;
+	contextBridge.exposeInMainWorld('isElectron', true);
 
 	initSpellcheck()
-		.then(() => addSpellCheckMenuItem())
 		.catch(e => console.error(e));
 }
 
 async function initSpellcheck(): Promise<void> {
 	await localforage.ready();
 
-	shouldSpellCheck = (await localforage.getItem<boolean>('should spell check')) !== false;
-	if (!shouldSpellCheck) {
-		ContextMenu({ showInspectElement: false });
+	let shouldSpellCheck = (await localforage.getItem<boolean>('should spell check')) !== false;
+	userDict = new Set(await localforage.getItem<string[]>('user dict'));
+
+	ipcRenderer.on('updateShouldSpellCheck', async (event, newShouldSpellCheck) => {
+		await localforage.setItem<boolean>('should spell check', newShouldSpellCheck);
+	});
+	ipcRenderer.on('addToUserDict', async (event, misspelledWord) => {
+		userDict.add(misspelledWord);
+		await localforage.setItem('user dict', Array.from(userDict));
+	});
+
+	ipcRenderer.send('initalShouldSpellCheck', shouldSpellCheck );
+
+	if(!shouldSpellCheck){
 		return;
 	}
 
-	const dictAU = new Typo('en_AU', await readFile(path.join(__dirname, 'node_modules/dictionary-en-au/index.aff')), await readFile(path.join(__dirname, '/node_modules/dictionary-en-au/index.dic')));
-	const dictUS = new Typo('en_US', await readFile(path.join(__dirname, 'node_modules/dictionary-en/index.aff')), await readFile(path.join(__dirname, '/node_modules/dictionary-en/index.dic')));
-
-	userDict = new Set(await localforage.getItem<string[]>('user dict'));
+	const dicts = await getDicts();
 
 	setTimeout(() => {
 		webFrame.setSpellCheckProvider('en-AU', {
 			spellCheck(words, callback) {
 				const misspelt = words
 					.filter(word => !/\d/.test(word)) // Don't spellcheck anything with a number in it
-					.filter(word => !(userDict.has(word) || dictAU.check(word) || dictUS.check(word)));
+					.filter(word => !(userDict.has(word) || dicts.AU.check(word) || dicts.US.check(word)));
 
 				callback(misspelt);
 			}
 		});
 	}, 1000);
-
-	(() => {
-		ContextMenu({
-			menu: (defaultActions, params) => {
-				const spellSuggestions = params.misspelledWord
-					? Array.from(new Set([...dictAU.suggest(params.misspelledWord), ...dictUS.suggest(params.misspelledWord)]))
-					: [];
-
-				const spellSuggestionOptions = spellSuggestions.map(w => {
-					return {
-						label: w,
-						click(selected) {
-							// Replace selected text
-							const replacement: string = selected.label;
-							const input: HTMLInputElement = document.activeElement as HTMLInputElement;
-							const start = input.selectionStart;
-							const end = input.selectionEnd;
-							if (start === null || end === null) {
-								return;
-							}
-
-							const replacementEnd = start + replacement.length;
-
-							setNativeValue(input, input.value.substring(0, start) + replacement + input.value.substring(end, input.value.length));
-							input.setSelectionRange(replacementEnd, replacementEnd);
-							input.dispatchEvent(new Event('input', { bubbles: true }));
-						}
-					};
-				});
-
-				const learnSpelling = params.misspelledWord ? [
-					defaultActions.separator(),
-					{
-						label: 'Add to dictionary',
-						click() {
-							userDict.add(params.misspelledWord);
-							localforage.setItem('user dict', Array.from(userDict));
-						}
-					}
-				] : [];
-
-				return [
-					...spellSuggestionOptions,
-					...learnSpelling,
-					defaultActions.separator(),
-					defaultActions.lookUpSelection({}),
-					defaultActions.separator(),
-					defaultActions.searchWithGoogle({}),
-					defaultActions.cut({}),
-					defaultActions.copy({}),
-					defaultActions.paste({}),
-					defaultActions.separator(),
-					defaultActions.saveImage({}),
-					defaultActions.saveImageAs({}),
-					...(params.linkURL.startsWith('file:///') ? [] : [defaultActions.copyLink({})]),
-					defaultActions.copyImage({}),
-				];
-			}
-		});
-	})();
-}
-
-function addSpellCheckMenuItem() {
-	const menu = Menu.getApplicationMenu() as any;
-	menu.getMenuItemById('edit-menu').submenu.append(new MenuItem({
-		type: 'checkbox',
-		label: 'Spell Checking',
-		checked: shouldSpellCheck,
-		click: async menuItem => {
-			await localforage.setItem<boolean>('should spell check', menuItem.checked);
-			await dialog.showMessageBox({ message: `When you restart µPad, the spell checker will be ${menuItem.checked ? 'enabled' : 'disabled'}.` });
-		}
-	}));
-}
-
-// Thanks to https://github.com/facebook/react/issues/10135#issuecomment-314441175
-function setNativeValue(element: HTMLInputElement, value: string) {
-	const valueProp = Object.getOwnPropertyDescriptor(element, 'value') ?? Object.getOwnPropertyDescriptor(element['__proto__'], 'value');
-
-	const valueSetter = valueProp?.set;
-	const prototype = Object.getPrototypeOf(element);
-	const prototypeValueSetter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
-
-	if (valueSetter && valueSetter !== prototypeValueSetter) {
-		prototypeValueSetter?.call(element, value);
-	} else {
-		valueSetter!.call(element, value);
-	}
 }
 
 function readFile(path: string): Promise<string> {
@@ -144,10 +55,6 @@ function readFile(path: string): Promise<string> {
 			resolve(data.toString());
 		});
 	});
-}
-
-function getWindow(): IWindow {
-	return window as any;
 }
 
 init();

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,11 +31,6 @@
     global-agent "^3.0.0"
     global-tunnel-ng "^2.7.1"
 
-"@electron/remote@^2.0.1":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-2.0.8.tgz#85ff321f0490222993207106e2f720273bb1a5c3"
-  integrity sha512-P10v3+iFCIvEPeYzTWWGwwHmqWnjoh8RYnbtZAb3RlQefy4guagzIwcWtfftABIfm6JJTNQf4WPSKWZOpLmHXw==
-
 "@electron/universal@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@electron/universal/-/universal-1.2.0.tgz#518cac72bccd79c00bf41345119e6fdbabdb871d"
@@ -743,11 +738,11 @@ electron-builder@^23.0.2:
     update-notifier "^5.1.0"
     yargs "^17.0.1"
 
-"electron-context-menu@git+https://github.com/NickGeek/electron-context-menu.git#97ee9ecd43b9fd2186b085d4a5b8732ff99fcee6":
+electron-context-menu@^3.1.2:
   version "3.1.2"
-  resolved "git+https://github.com/NickGeek/electron-context-menu.git#97ee9ecd43b9fd2186b085d4a5b8732ff99fcee6"
+  resolved "https://registry.yarnpkg.com/electron-context-menu/-/electron-context-menu-3.1.2.tgz#0f550e47df39cb25c03e0f4bf840ce5c9fefcdd5"
+  integrity sha512-nNzu4w14n7mOR+4cLjRC9cEFqGUsAY76seOm0sw3f4OxEfX/d75m7HYekyp5b+0m7Ixy2KN/Mrljw1zLmpyV2w==
   dependencies:
-    "@electron/remote" "^2.0.1"
     cli-truncate "^2.1.0"
     electron-dl "^3.2.1"
     electron-is-dev "^2.0.0"
@@ -761,12 +756,10 @@ electron-dl@^3.2.1:
     pupa "^2.0.1"
     unused-filename "^2.1.0"
 
-electron-is-dev@^2.0.0, "electron-is-dev@git+https://github.com/NickGeek/electron-is-dev.git#a5350fb9f004106a2f0d8bd7eb27d4fcd179dada":
-  version "2.0.1"
-  uid a5350fb9f004106a2f0d8bd7eb27d4fcd179dada
-  resolved "git+https://github.com/NickGeek/electron-is-dev.git#a5350fb9f004106a2f0d8bd7eb27d4fcd179dada"
-  dependencies:
-    "@electron/remote" "^2.0.1"
+electron-is-dev@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-2.0.0.tgz#833487a069b8dad21425c67a19847d9064ab19bd"
+  integrity sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==
 
 electron-osx-sign@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
This patch removes the use of @electron/remote and enables contextIsolation. All communication between the main and
renderer processes, mostly involving spell checking state, now happens over defined IPC channels.